### PR TITLE
change(font): from simhei to noto sans sc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Change from `SimHei` to `Noto Sans SC`
+
 
 ## [0.1.0] - 2024-11-30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,8 @@ include = ["zhplot*"]
 namespaces = false
 
 [tool.setuptools.package-data]
-zhplot = ["./fonts/*.ttf"]
+zhplot = ["./fonts/*.ttf", "./fonts/*.txt"]
+
 
 [tool.isort]
 profile = "black"

--- a/tests/test_matplotlib.py
+++ b/tests/test_matplotlib.py
@@ -15,6 +15,6 @@ def test_chinese_font_config():
     """Test if matplotlib is configured to use Chinese fonts."""
     # Check if SimHei is in the font family settings after the import
     assert (
-        "simhei" in plt.rcParams["font.family"]
-        or any("simhei" in name.lower() for name in plt.rcParams["font.sans-serif"])
+        "Noto Sans SC" in plt.rcParams["font.family"]
+        or any("Noto Sans SC" in name.lower() for name in plt.rcParams["font.sans-serif"])
     ) is True

--- a/zhplot/fonts/OFL.txt
+++ b/zhplot/fonts/OFL.txt
@@ -1,0 +1,93 @@
+Copyright 2014-2021 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/zhplot/fonts/README.txt
+++ b/zhplot/fonts/README.txt
@@ -1,0 +1,71 @@
+Noto Sans SC Variable Font
+==========================
+
+This download contains Noto Sans SC as both a variable font and static fonts.
+
+Noto Sans SC is a variable font with this axis:
+  wght
+
+This means all the styles are contained in a single file:
+  NotoSansSC-VariableFont_wght.ttf
+
+If your app fully supports variable fonts, you can now pick intermediate styles
+that aren’t available as static fonts. Not all apps support variable fonts, and
+in those cases you can use the static font files for Noto Sans SC:
+  static/NotoSansSC-Thin.ttf
+  static/NotoSansSC-ExtraLight.ttf
+  static/NotoSansSC-Light.ttf
+  static/NotoSansSC-Regular.ttf
+  static/NotoSansSC-Medium.ttf
+  static/NotoSansSC-SemiBold.ttf
+  static/NotoSansSC-Bold.ttf
+  static/NotoSansSC-ExtraBold.ttf
+  static/NotoSansSC-Black.ttf
+
+Get started
+-----------
+
+1. Install the font files you want to use
+
+2. Use your app's font picker to view the font family and all the
+available styles
+
+Learn more about variable fonts
+-------------------------------
+
+  https://developers.google.com/web/fundamentals/design-and-ux/typography/variable-fonts
+  https://variablefonts.typenetwork.com
+  https://medium.com/variable-fonts
+
+In desktop apps
+
+  https://theblog.adobe.com/can-variable-fonts-illustrator-cc
+  https://helpx.adobe.com/nz/photoshop/using/fonts.html#variable_fonts
+
+Online
+
+  https://developers.google.com/fonts/docs/getting_started
+  https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide
+  https://developer.microsoft.com/en-us/microsoft-edge/testdrive/demos/variable-fonts
+
+Installing fonts
+
+  MacOS: https://support.apple.com/en-us/HT201749
+  Linux: https://www.google.com/search?q=how+to+install+a+font+on+gnu%2Blinux
+  Windows: https://support.microsoft.com/en-us/help/314960/how-to-install-or-remove-a-font-in-windows
+
+Android Apps
+
+  https://developers.google.com/fonts/docs/android
+  https://developer.android.com/guide/topics/ui/look-and-feel/downloadable-fonts
+
+License
+-------
+Please read the full license text (OFL.txt) to understand the permissions,
+restrictions and requirements for usage, redistribution, and modification.
+
+You can use them in your products & projects – print or digital,
+commercial or otherwise.
+
+This isn't legal advice, please consider consulting a lawyer and see the full
+license for all details.

--- a/zhplot/matplotlib.py
+++ b/zhplot/matplotlib.py
@@ -7,8 +7,8 @@ from matplotlib import font_manager
 
 @dataclass
 class MatplotlibChineseize:
-    font_name: str = "simhei"
-    font_ttf: str = "simhei.ttf"
+    font_name: str = "Noto Sans SC"
+    font_ttf: str = "NotoSansSC-Regular.ttf"
 
     def __post_init__(self):
         self.font_dir_path = Path(__file__).parent / "fonts"
@@ -18,6 +18,7 @@ class MatplotlibChineseize:
         # Ref: https://github.com/uehara1414/japanize-matplotlib
         font_files = font_manager.findSystemFonts(fontpaths=[self.font_dir_path])
         for fpath in font_files:
+            print(fpath)
             font_manager.fontManager.addfont(fpath)
         matplotlib.rc("font", family=self.font_name)
 

--- a/zhplot/matplotlib.py
+++ b/zhplot/matplotlib.py
@@ -18,7 +18,6 @@ class MatplotlibChineseize:
         # Ref: https://github.com/uehara1414/japanize-matplotlib
         font_files = font_manager.findSystemFonts(fontpaths=[self.font_dir_path])
         for fpath in font_files:
-            print(fpath)
             font_manager.fontManager.addfont(fpath)
         matplotlib.rc("font", family=self.font_name)
 


### PR DESCRIPTION
Fix #7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced support for the Noto Sans SC font in Matplotlib, enhancing the visual presentation of plots.
	- Added comprehensive documentation for the Noto Sans SC Variable Font, including installation instructions and usage guidelines.

- **Changes**
	- Updated the default font settings from SimHei to Noto Sans SC in the Matplotlib configuration.
	- Expanded package data to include additional font file types.

- **Documentation**
	- Added licensing information for the font software and a README for user guidance on font usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->